### PR TITLE
Major Update

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+records*
+aarlo/
+venv/
+.git/
+.github/
+__pycache__/
+*.code-workspace
+.env
+docker-compose.yml
+test-windows.bat
+LICENSE
+README.md
+SECURITY.md

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+ARLO_USERNAME=<your_arlo_username>
+ARLO_PASSWORD=<your_arlo_password>
+TFA_TYPE=PUSH
+TFA_SOURCE=push
+TFA_HOST=
+TFA_USERNAME=
+TFA_PASSWORD=
+MEDIA_FOLDER=/records
+FILENAME=${Y}/${m}/${F}T${t}_${N}_${SN}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Build and Push docker image on Dockerhub
 
 on:
   push:
-    branches: [ "main", "feature/*", "maintenance/*" ]
+    branches: [ "feature/*", "maintenance/*" ]
   pull_request:
-    branches: [ "main", "feature/*", "maintenance/*" ]
+    branches: [ "feature/*", "maintenance/*" ]
   
 jobs:
   build_push:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -88,15 +88,11 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        # list of Docker images to use as base name for tags
         images: |
           diaznet/arlo-downloader
           ghcr.io/diaznet/arlo-downloader
-        # generate Docker tags based on the following events/attributes
         tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
+          type=ref,event=branch,enable=${{ github.event_name != 'workflow_dispatch' }}
           type=ref,event=tag
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
@@ -110,14 +106,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    # Log in to Docker Hub
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    # Log-in to GHCR.io
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -125,18 +119,15 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}     
 
-    # Checkout
     - uses: actions/checkout@v4
 
-    # Build and push Docker image
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
       with:
         context: .
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
   
-    # Log-out of Docker Hub
     - name: Log out of Docker Hub
       run: docker logout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,13 +2,83 @@ name: Build and Push docker image on Dockerhub
 
 on:
   push:
-    branches: [ "feature/*", "maintenance/*" ]
+    branches: ["main"]
+    tags: ["v*"]
   pull_request:
-    branches: [ "feature/*", "maintenance/*" ]
+    branches: ["main"]
   
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - run: pip install ruff
+    - run: ruff check .
+    - run: ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build test image
+      run: docker build -t arlo-downloader:test .
+
+    - name: Test - old config is rejected
+      run: |
+        output=$(docker run --rm \
+          -e 'MEDIA_FOLDER=/records/${Y}/${m}/${F}T${t}_${N}_${SN}' \
+          arlo-downloader:test 2>&1 || true)
+        echo "$output"
+        echo "$output" | grep -q "Breaking changes"
+
+    - name: Test - missing credentials are caught
+      run: |
+        output=$(docker run --rm \
+          -e MEDIA_FOLDER=/records \
+          arlo-downloader:test 2>&1 || true)
+        echo "$output"
+        echo "$output" | grep -q "ARLO_USERNAME and ARLO_PASSWORD environment variables are required"
+
+    - name: Test - new config produces correct save_media_to
+      run: |
+        output=$(docker run --rm \
+          -e MEDIA_FOLDER=/records \
+          -e 'FILENAME=${Y}/${m}/${F}T${t}_${N}_${SN}' \
+          -e ARLO_USERNAME=test@test.com \
+          -e ARLO_PASSWORD=testpass \
+          arlo-downloader:test 2>&1 || true)
+        echo "$output"
+        echo "$output" | grep -q 'save_media_to: /records/\${Y}/\${m}/\${F}T\${t}_\${N}_\${SN}'
+
+    - name: Test - defaults work when FILENAME is not set
+      run: |
+        output=$(docker run --rm \
+          -e MEDIA_FOLDER=/records \
+          -e ARLO_USERNAME=test@test.com \
+          -e ARLO_PASSWORD=testpass \
+          arlo-downloader:test 2>&1 || true)
+        echo "$output"
+        echo "$output" | grep -q 'save_media_to: /records/\${Y}/\${m}/\${F}T\${t}_\${N}_\${SN}'
+
+    - name: Test - custom filename pattern
+      run: |
+        output=$(docker run --rm \
+          -e MEDIA_FOLDER=/data \
+          -e 'FILENAME=${SN}/${F}_${t}' \
+          -e ARLO_USERNAME=test@test.com \
+          -e ARLO_PASSWORD=testpass \
+          arlo-downloader:test 2>&1 || true)
+        echo "$output"
+        echo "$output" | grep -q 'save_media_to: /data/\${SN}/\${F}_\${t}'
+
   build_push:
     runs-on: ubuntu-latest
+    needs: test
 
     steps:
 
@@ -40,14 +110,14 @@ jobs:
 
     # Log in to Docker Hub
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     # Log-in to GHCR.io
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3.3.0
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
   
 jobs:
   lint:
@@ -79,6 +80,7 @@ jobs:
   build_push:
     runs-on: ubuntu-latest
     needs: test
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
 
     steps:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Build and Push docker image on Dockerhub
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "feature/*", "maintenance/*"]
     tags: ["v*"]
   pull_request:
     branches: ["main"]

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ records/
 docker-compose.yml
 __pycache__/
 aarlo/
-.venv
+venv
+arlo-downloader.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ records/
 docker-compose.yml
 __pycache__/
 aarlo/
-venv
+venv/
+.env
 arlo-downloader.code-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN useradd arlo-downloader
 # Switch to arlo-downloader directory
 WORKDIR /arlo-downloader
 
-COPY requirements.txt arlo-downloader.py config.py entrypoint.sh .
+COPY requirements.txt arlo-downloader.py config.py entrypoint.sh /arlo-downloader/
 
 # Update PIP to latest version and install required package(s)
 RUN pip install --upgrade pip && pip install -r requirements.txt
@@ -18,14 +18,14 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 ENTRYPOINT ["/arlo-downloader/entrypoint.sh"]
 
 # Start the arlo-downloader.py script
-CMD [                                                                   \
-    "python",               "/arlo-downloader/arlo-downloader.py",      \
-        "--save-media-to",  "'/records/${Y}/${m}/${F}T${t}_${N}_${SN}'",\
-        "--tfa-type",       "${TFA_TYPE:=PUSH}",                        \
-        "--tfa-source",     "${TFA_SOURCE:=push}",                      \
-        "--tfa-retries",    "${TFA_RETRIES:=10}",                       \
-        "--tfa-delay",      "${TFA_DELAY:=5}",                          \
-        "--tfa-host",       "${TFA_HOST:=_invalid}",                    \
-        "--tfa-username",   "${TFA_USERNAME:=_invalid}",                \
-        "--tfa-password",   "${TFA_PASSWORD:=_invalid}"                 \
+CMD [                                                                               \
+    "python",               "/arlo-downloader/arlo-downloader.py",                  \
+        "--save-media-to",  "${MEDIA_FOLDER:=/records/$$Y/$$m/$$FT$$t_$$N_$$SN}",   \
+        "--tfa-type",       "${TFA_TYPE:=PUSH}",                                    \
+        "--tfa-source",     "${TFA_SOURCE:=push}",                                  \
+        "--tfa-retries",    "${TFA_RETRIES:=10}",                                   \
+        "--tfa-delay",      "${TFA_DELAY:=5}",                                      \
+        "--tfa-host",       "${TFA_HOST:=_invalid}",                                \
+        "--tfa-username",   "${TFA_USERNAME:=###}",                                 \
+        "--tfa-password",   "${TFA_PASSWORD:=###}"                                  \
     ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,22 @@
 FROM python:3.12-slim
 
-# Create the working directories
-RUN mkdir /arlo-downloader /records
+ENV PUID=1000
+ENV PGID=1000
 
-# Add user
-RUN useradd arlo-downloader
+RUN mkdir /arlo-downloader /records /arlo-downloader/aarlo && \
+    groupadd -g ${PGID} arlo-downloader && \
+    useradd -u ${PUID} -g arlo-downloader arlo-downloader && \
+    chown -R arlo-downloader:arlo-downloader /records /arlo-downloader
 
-# Switch to arlo-downloader directory
 WORKDIR /arlo-downloader
 
-COPY requirements.txt arlo-downloader.py config.py entrypoint.sh /arlo-downloader/
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
 
-# Update PIP to latest version and install required package(s)
-RUN pip install --upgrade pip && pip install -r requirements.txt
+COPY arlo-downloader.py config.py entrypoint.sh ./
+RUN chmod +x entrypoint.sh
 
-# Setting our entrypoint
+USER arlo-downloader
+
 ENTRYPOINT ["/arlo-downloader/entrypoint.sh"]
-
-# Start the arlo-downloader.py script
-CMD [                                                                               \
-    "python",               "/arlo-downloader/arlo-downloader.py",                  \
-        "--save-media-to",  "${MEDIA_FOLDER:=/records/$$Y/$$m/$$FT$$t_$$N_$$SN}",   \
-        "--tfa-type",       "${TFA_TYPE:=PUSH}",                                    \
-        "--tfa-source",     "${TFA_SOURCE:=push}",                                  \
-        "--tfa-retries",    "${TFA_RETRIES:=10}",                                   \
-        "--tfa-delay",      "${TFA_DELAY:=5}",                                      \
-        "--tfa-host",       "${TFA_HOST:=_invalid}",                                \
-        "--tfa-username",   "${TFA_USERNAME:=###}",                                 \
-        "--tfa-password",   "${TFA_PASSWORD:=###}"                                  \
-    ]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In order to ensure the camera recordings are permanently backup'ed, we'll automa
 
 - Downloads all recordings available from Arlo cloud storage locally.
 - Handles TFA with EMAIL or PUSH methods (see below and [instructions](https://github.com/twrecked/pyaarlo#2fa-imap) for EMAIL type)
-
+- Handles custom file and path naming (See below and [Instructions](https://github.com/twrecked/pyaarlo#saving-media) for formatting)
 
 # Requirements
 
@@ -74,31 +74,36 @@ As an example, instead of using -e ARLO_PASSWORD, you can set the following envi
 It will then set the environment variable ARLO_PASSWORD based on the contents of the /run/secrets/myarlopassword file.
 
 
-### docker-compose
+### docker-compose (recommended)
 
 Create a file called docker-compose.yml with the following content: 
 
 ```yaml
-version: "2.1"
+version: "2"
 services:
   arlo-downloader:
     image: diaznet/arlo-downloader:latest
-    build: .
     container_name: arlo-downloader:latest
     environment:
-      - ARLO_USERNAME=<api_username>
-      - ARLO_PASSWORD=<password>
+      ARLO_USERNAME: <api_username>
+      ARLO_PASSWORD: <password>
+      MEDIA_FOLDER: "/records/example/$${Y}/$${m}/$${F}T$${t}_$${N}_$${SN}" # See format at https://github.com/twrecked/pyaarlo#saving-media
+      # Optional if you have 2FA activated on your account. Example with EMAIL method and imaps server
+      # See https://github.com/twrecked/pyaarlo#2fa-imap
+      TFA_TYPE: EMAIL
+      TFA_SOURCE: imap
+      TFA_HOST: mail.server.com:993
+      TFA_USERNAME: <email_username>
+      TFA_PASSWORD: <email_password>
     volumes:
       - /path/to/videos:/records
     restart: unless-stopped
 ```
 
-Note: you are also going to need the various TFA_* environmetn variables if yu have 2FA activated on your account.
-
-Build and start the docker containers with docker-compose up. To run the containers in the background add the -d flag:
+Start the docker containers with docker-compose up. To run the containers in the background add the -d flag:
 
 ```bash
-docker-compose up --build -d
+docker compose up -d
 ```
 
 ### docker cli

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order to ensure the camera recordings are permanently backup'ed, we'll automa
 # Requirements
 
 - Arlo cameras and My Arlo account, obviously.
-- Docker _(if you are new to Docker, see [Installing Docker and Docker Compose](https://dev.to/rohansawant/installing-docker-and-docker-compose-on-the-raspberry-pi-in-5-simple-steps-3mgl))_
+- Docker or Podman _(if you are new to Docker, see [Installing Docker and Docker Compose](https://dev.to/rohansawant/installing-docker-and-docker-compose-on-the-raspberry-pi-in-5-simple-steps-3mgl))_
 - Arlo Mobile App, if using TFA with PUSH method.
 
 # Instructions
@@ -53,109 +53,173 @@ This way your main account is not used by Arlo Downloader and access can be revo
 
 | Parameter | Function | Default |
 | :----: | --- | --- |
-| -e `TFA_TYPE` | Arlo TFA type. Currently only supports push,email | push |
-| -e `TFA_SOURCE` | Arlo TFA type. Currently only supports push,imap | push |
-| -e `TFA_RETRIES` | Arlo TFA retries. | 10 |
-| -e `TFA_DELAY` | Arlo TFA Delay between each check | 5 |
+| -e `MEDIA_FOLDER` | Base folder for media storage | /records |
+| -e `FILENAME` | File naming pattern ([substitutions](https://github.com/twrecked/pyaarlo#saving-media)) | `${Y}/${m}/${F}T${t}_${N}_${SN}` |
+| -e `TFA_TYPE` | Arlo TFA type. Currently only supports PUSH, EMAIL | PUSH |
+| -e `TFA_SOURCE` | Arlo TFA source. Currently only supports push, imap | push |
+| -e `TFA_RETRIES` | Arlo TFA retries | 10 |
+| -e `TFA_DELAY` | Arlo TFA delay between each check | 5 |
 | -e `TFA_HOST` | TFA_TYPE=EMAIL + TFA_SOURCE=imap only [Instructions](https://github.com/twrecked/pyaarlo#2fa-imap) | |
 | -e `TFA_USERNAME` | TFA_TYPE=EMAIL + TFA_SOURCE=imap only [Instructions](https://github.com/twrecked/pyaarlo#2fa-imap) | |
 | -e `TFA_PASSWORD` | TFA_TYPE=EMAIL + TFA_SOURCE=imap only [Instructions](https://github.com/twrecked/pyaarlo#2fa-imap) | |
 | -e `DEBUG` | Set to 1 to enable debug logs | 0 |
 
-#### Environment variables from files (Docker secrets)
-You can set any environment variable from a file by using a special prepend FILE__.
+#### Filename substitutions
 
-As an example, instead of using -e ARLO_PASSWORD, you can set the following environment variable:
+The `FILENAME` parameter supports [pyaarlo substitutions](https://github.com/twrecked/pyaarlo#saving-media):
+
+| Token | Description |
+| :----: | --- |
+| `${SN}` | Device serial number |
+| `${N}` | Device name |
+| `${NN}` | Device name, lower case with _ replacing spaces |
+| `${Y}` | Year (4 digits) |
+| `${m}` | Month (01-12) |
+| `${d}` | Day (01-31) |
+| `${H}` | Hour (00-23) |
+| `${M}` | Minute (00-59) |
+| `${S}` | Second (00-59) |
+| `${F}` | Shortcut for `${Y}-${m}-${d}` |
+| `${T}` | Shortcut for `${H}:${M}:${S}` |
+| `${t}` | Shortcut for `${H}-${M}-${S}` |
+| `${s}` | Seconds since epoch |
+
+The file extension is added automatically by pyaarlo.
+
+#### Environment variables from files (Docker secrets)
+
+You can set any environment variable from a file by using a special prepend `FILE__`.
+
+As an example, instead of using `-e ARLO_PASSWORD`, you can set the following environment variable:
 
 ```bash
 -e FILE__ARLO_PASSWORD=/run/secrets/myarlopassword
 ```
 
-It will then set the environment variable ARLO_PASSWORD based on the contents of the /run/secrets/myarlopassword file.
-
+It will then set the environment variable `ARLO_PASSWORD` based on the contents of the `/run/secrets/myarlopassword` file.
 
 ### docker-compose (recommended)
 
-Create a file called docker-compose.yml with the following content: 
+1. Copy the example environment file and fill in your credentials:
+
+```bash
+cp .env.example .env
+# Edit .env with your real credentials
+```
+
+2. Create a file called `docker-compose.yml`:
 
 ```yaml
-version: "2"
 services:
   arlo-downloader:
     image: diaznet/arlo-downloader:latest
-    container_name: arlo-downloader:latest
+    container_name: arlo-downloader
+    env_file: .env
     environment:
-      ARLO_USERNAME: <api_username>
-      ARLO_PASSWORD: <password>
-      MEDIA_FOLDER: "/records/example/$${Y}/$${m}/$${F}T$${t}_$${N}_$${SN}" # See format at https://github.com/twrecked/pyaarlo#saving-media
-      # Optional if you have 2FA activated on your account. Example with EMAIL method and imaps server
-      # See https://github.com/twrecked/pyaarlo#2fa-imap
-      TFA_TYPE: EMAIL
-      TFA_SOURCE: imap
-      TFA_HOST: mail.server.com:993
-      TFA_USERNAME: <email_username>
-      TFA_PASSWORD: <email_password>
+      MEDIA_FOLDER: "/records"
+      FILENAME: "$${Y}/$${m}/$${F}T$${t}_$${N}_$${SN}"
+      # Optional: TFA with EMAIL method and IMAP server
+      # TFA_TYPE: EMAIL
+      # TFA_SOURCE: imap
+      # TFA_HOST: mail.server.com:993
+      # TFA_USERNAME: <email_username>
+      # TFA_PASSWORD: <email_password>
     volumes:
       - /path/to/videos:/records
+      - aarlo-state:/arlo-downloader/aarlo
     restart: unless-stopped
+
+volumes:
+  aarlo-state:
 ```
 
-Start the docker containers with docker-compose up. To run the containers in the background add the -d flag:
+> **Note:** Use `$$` to escape `$` in docker-compose environment values (e.g., `$${Y}` becomes `${Y}` inside the container).
+
+3. Start the container:
 
 ```bash
 docker compose up -d
 ```
 
-### docker cli
+### docker / podman cli
 
 ```bash
 docker run -d \
   --name=arlo-downloader \
   -e ARLO_USERNAME=<api_username> \
   -e ARLO_PASSWORD=<password> \
+  -e MEDIA_FOLDER=/records \
+  -e 'FILENAME=${Y}/${m}/${F}T${t}_${N}_${SN}' \
   -v /path/to/videos:/records \
+  -v aarlo-state:/arlo-downloader/aarlo \
   --restart unless-stopped \
   diaznet/arlo-downloader:latest
 ```
 
-Once the container is started, it will first download into /path/to/videos all available recordings from the API.  
+Once the container is started, it will first download into `/path/to/videos` all available recordings from the API.  
 If files already exist, they will not be replaced.  
 It will then run indefinitely and download any new recording as soon as it becomes available in the API.
 
-Default Naming scheme:
+Default naming scheme:
 
-    <year>/<month_number>/<year>-<month_number>-<day_number>T<hour>:<minute>:<seconds>_<device_name>_<device_serial_number>
+    <media_folder>/<year>/<month_number>/<year>-<month_number>-<day_number>T<hour>-<minute>-<seconds>_<device_name>_<device_serial_number>.mp4
 
 ## Manual Script run
 
-The script can also be ran manually.
+The script can also be run manually.
 
 ```bash
-usage: arlo-downloader.py [-h] [-d] [-m SAVE_MEDIA_TO] [-t {PUSH,EMAIL}] [-s {push,imap}] [-r TFA_RETRIES]
-                          [-T TFA_DELAY] [-H TFA_HOST] [-U TFA_USERNAME] [-P TFA_PASSWORD]
+usage: arlo-downloader.py [-h] [-d] [-m MEDIA_FOLDER] [-f FILENAME] [-t {PUSH,EMAIL}]
+                          [-s {push,imap}] [-r TFA_RETRIES] [-D TFA_DELAY]
+                          [-H TFA_HOST] [-U TFA_USERNAME] [-P TFA_PASSWORD]
 
 Download records from Arlo Cameras.
 
 optional arguments:
   -h, --help            show this help message and exit
   -d, --debug           Enable Debug messages. Can also be set with environment variable DEBUG=1
-  -m SAVE_MEDIA_TO, --save-media-to SAVE_MEDIA_TO
-                        Save Media naming scheme without extension (default = '/records/
-                        ${Y}/${m}/${F}T${t}_${N}_${SN}')
+  -m MEDIA_FOLDER, --media-folder MEDIA_FOLDER
+                        Base folder for media storage (default = './records')
+  -f FILENAME, --filename FILENAME
+                        File naming pattern using pyaarlo substitutions
+                        (default = '${Y}/${m}/${F}T${t}_${N}_${SN}')
   -t {PUSH,EMAIL}, --tfa-type {PUSH,EMAIL}
                         Set TFA type (default = 'PUSH')
   -s {push,imap}, --tfa-source {push,imap}
                         Set TFA source (default = 'push')
   -r TFA_RETRIES, --tfa-retries TFA_RETRIES
-                        Set TFA max retries (default = 10).
-  -T TFA_DELAY, --tfa-timeout TFA_TIMEOUT
-                        Set TFA timeout (default = 5).
+                        Set TFA max retries (default = 10)
+  -D TFA_DELAY, --tfa-delay TFA_DELAY
+                        Set TFA delay between each check (default = 5)
   -H TFA_HOST, --tfa-host TFA_HOST
-                        (EMAIL/imap only) Set TFA host (default = ).
+                        (EMAIL/imap only) Set TFA host
   -U TFA_USERNAME, --tfa-username TFA_USERNAME
-                        (EMAIL/imap only) Set TFA username (default = ).
+                        (EMAIL/imap only) Set TFA username
   -P TFA_PASSWORD, --tfa-password TFA_PASSWORD
-                        (EMAIL/imap only) Set TFA password (default = ).
+                        (EMAIL/imap only) Set TFA password
+```
+
+Example:
+
+```bash
+export ARLO_USERNAME=<your_username>
+export ARLO_PASSWORD=<your_password>
+python arlo-downloader.py -m "./records" -f '${Y}/${m}/${F}T${t}_${N}_${SN}' -t EMAIL -s imap -H mail.server.com:993 -U <email> -P <password>
+```
+
+# Development
+
+Install dev dependencies:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Run linting:
+
+```bash
+ruff check .
+ruff format --check .
 ```
 
 # Disclaimer
@@ -164,9 +228,7 @@ This application comes without warranty.
 Please use with care.
 Any damage cannot be related back to the author.
 
-# Todo's
-- Ability to customize video filenames / filepath
-
 # Credits
+
 Author: Jeremy Diaz  
 This container uses [pyaarlo](https://github.com/twrecked/pyaarlo) 0.8 library.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This way your main account is not used by Arlo Downloader and access can be revo
 | -e `TFA_HOST` | TFA_TYPE=EMAIL + TFA_SOURCE=imap only [Instructions](https://github.com/twrecked/pyaarlo#2fa-imap) | |
 | -e `TFA_USERNAME` | TFA_TYPE=EMAIL + TFA_SOURCE=imap only [Instructions](https://github.com/twrecked/pyaarlo#2fa-imap) | |
 | -e `TFA_PASSWORD` | TFA_TYPE=EMAIL + TFA_SOURCE=imap only [Instructions](https://github.com/twrecked/pyaarlo#2fa-imap) | |
+| -e `CIPHER_LIST` | Override TLS cipher list (set to `default` if you get Cloudflare 403 errors) | |
 | -e `DEBUG` | Set to 1 to enable debug logs | 0 |
 
 #### Filename substitutions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-For reporting a security vulnerability, please contact `security AT diaznet DOT fr`.
+For reporting a security vulnerability, please contact `security AT diaznet DOT ch`.

--- a/arlo-downloader.py
+++ b/arlo-downloader.py
@@ -1,148 +1,181 @@
 #!/usr/bin/env python
 
+"""
+Filename:       arlo-downloader.py
+Description:    Check README.md or -h cli flag to see documentation about usage of the script.
+Author:         Jeremy Diaz <jd@diaznet.ch>
+Date:           2022-01-05
+License:        MIT
+"""
+
 import logging
 import os
 import sys
+import asyncio
+from argparse import ArgumentParser, Namespace
+
 import pyaarlo
-import asyncio 
-import argparse
 
 from config import Config
 
-def parse_arguments():
-    
-    parser = argparse.ArgumentParser(description='Download records from Arlo Cameras.')
+
+def parse_arguments() -> Namespace:
+    """
+    This is a function that parses arguments given in the shell to the CLI.
+
+    Returns:
+        Namespace: A Namespace containing all arguments
+    """
+
+    parser = ArgumentParser(description='Download records from Arlo Cameras.')
     parser.add_argument('-d',
-                       '--debug',
-                       action='store_true',
-                       help='Enable Debug messages. Can also be set with environment variable DEBUG=1')
+                        '--debug',
+                        action='store_true',
+                        help='Enable Debug messages. Can also be set with environment variable DEBUG=1')
     parser.add_argument('-m',
                         '--save-media-to',
-                        help="Save Media naming scheme without extension (default = \'{}\')".format(Config.config("save_media_to")),
+                        help=f"Save Media naming scheme without extension (default = '{Config.config("save_media_to")}').",
                         action='store')
     parser.add_argument('-t',
                         '--tfa-type',
                         choices=['PUSH', 'EMAIL'],
-                        help="Set TFA type (default = \'{}\')".format(Config.config("tfa_type")),
+                        help=f"Set TFA type (default = '{Config.config("tfa_type")}').",
                         action='store')
     parser.add_argument('-s',
                         '--tfa-source',
                         choices=['push', 'imap'],
-                        help="Set TFA source (default = \'{}\')".format(Config.config("tfa_source")),
+                        help=f"Set TFA source (default = '{Config.config("tfa_source")}').",
                         action='store')
     parser.add_argument('-r',
                         '--tfa-retries',
-                        help="Set TFA max retries (default = {}).".format(Config.config("tfa_retries")),
+                        help=f"Set TFA max retries (default = {Config.config("tfa_retries")}).",
                         type=int,
                         action='store')
     parser.add_argument('-D',
                         '--tfa-delay',
-                        help="Set TFA delay between each check (default = {}).".format(Config.config("tfa_delay")),
+                        help=f"Set TFA delay between each check (default = {Config.config("tfa_delay")}).",
                         type=int,
                         action='store')
     parser.add_argument('-H',
                         '--tfa-host',
-                        help="(EMAIL/imap only) Set TFA host (default = {}).".format(Config.config("tfa_host")),
+                        help=f"(EMAIL/imap only) Set TFA host (default = {Config.config("tfa_host")}).",
                         action='store')
     parser.add_argument('-U',
                         '--tfa-username',
-                        help="(EMAIL/imap only) Set TFA username (default = {}).".format(Config.config("tfa_username")),
+                        help=f"(EMAIL/imap only) Set TFA username (default = {Config.config("tfa_username")}).",
                         action='store')
     parser.add_argument('-P',
                         '--tfa-password',
-                        help="(EMAIL/imap only) Set TFA password (default = {}).".format(Config.config("tfa_password")),
+                        help=f"(EMAIL/imap only) Set TFA password (default = {Config.config("tfa_password")}).",
                         action='store')
     args = parser.parse_args()
     return args
 
-def set_logger(dbg):
+
+def set_logger(dbg: bool) -> None:
+    """
+    Sets the logger to debug.
+
+    Args:
+        dbg (bool): Logger set to Debug if True
+    """
     level = logging.INFO
-    if (dbg):
+    if dbg:
         level = logging.DEBUG
     logging.basicConfig(level=level,
                         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                         datefmt="%Y-%m-%dT%H:%M:%S%z"
                         )
-    _LOGGER = logging.getLogger(__name__) 
 
-def Init():
 
+def init() -> None:
+    """
+    Initializes the connection to arlo and traps
+    """
     # code to trap when attributes change
     def attribute_changed(device, attr, value):
-        logging.info('attribute_changed:' + device.name + ':' + attr + ':' + str(value)[:80])
+        logging.info("attribute_changed: %s:%s:%s", device.name, attr, str(value)[:80])
 
     # set these from the environment to log in
-    USERNAME = os.environ.get('ARLO_USERNAME', '_INVALID')
-    PASSWORD = os.environ.get('ARLO_PASSWORD', '_INVALID')
-    
+    username = os.environ.get('ARLO_USERNAME', '_INVALID')
+    password = os.environ.get('ARLO_PASSWORD', '_INVALID')
+
     # Print configuration in DEBUG
-    for confItem in Config.dump_config().items(): logging.debug(confItem)
+    for conf_item in Config.dump_config().items():
+        logging.debug(conf_item)
     # log in
     # add `dump=True` to enable event stream packet dumps
-    arlo = pyaarlo.PyArlo(username=USERNAME, password=PASSWORD,
-                        tfa_type=Config.config('tfa_type'),
-                        tfa_source=Config.config('tfa_source'),
-                        tfa_retries=Config.config('tfa_retries'),
-                        tfa_delay=Config.config('tfa_delay'),
-                        tfa_host=Config.config('tfa_host'),
-                        tfa_username=Config.config('tfa_username'),
-                        tfa_password=Config.config('tfa_password'),
-                        synchronous_mode=False,
-                        mode_api='v2',
-                        save_state=True,
-                        dump=False,
-                        storage_dir='aarlo',
-                        save_media_to=Config.config('save_media_to'))
+    arlo = pyaarlo.PyArlo(username=username, password=password,
+                          tfa_type=Config.config('tfa_type'),
+                          tfa_source=Config.config('tfa_source'),
+                          tfa_retries=Config.config('tfa_retries'),
+                          tfa_delay=Config.config('tfa_delay'),
+                          tfa_host=Config.config('tfa_host'),
+                          tfa_username=Config.config('tfa_username'),
+                          tfa_password=Config.config('tfa_password'),
+                          synchronous_mode=False,
+                          mode_api='v2',
+                          save_state=True,
+                          dump=False,
+                          storage_dir='aarlo',
+                          save_media_to=Config.config('save_media_to'))
     if not arlo.is_connected:
-        logging.info("failed to login({})".format(arlo._last_error))
+        logging.info("failed to login: %s", arlo._last_error)
         sys.exit(-1)
 
     # get base stations, list their statuses, register state change callbacks
     for base in arlo.base_stations:
-        logging.info("base: name={},device_id={},state={}".format(base.name,base.device_id,base.state))
+        logging.info("base-name=%s, device_id=%s, state=%s", base.name, base.device_id, base.state)
         base.add_attr_callback('*', attribute_changed)
 
     # get cameras, list their statuses, register state change callbacks
     # * is any callback, you can use motionDetected just to get motion events
     for camera in arlo.cameras:
-        logging.info("camera: name={},device_id={},state={}".format(camera.name,camera.device_id,camera.state))
+        logging.info("camera: name=%s,device_id=%s,state=%s", camera.name, camera.device_id, camera.state)
         camera.add_attr_callback('*', attribute_changed)
 
-def main(arguments):
-     
+
+def main(args: Namespace):
+    """
+    Main entry point
+
+    Args:
+        args (Namespace): A Namespace containing all arguments
+    """
+
     loop = asyncio.get_event_loop()
-    if arguments.save_media_to:
-        Config.set("save_media_to", arguments.save_media_to)
-    if arguments.tfa_type:
-        Config.set("tfa_type", arguments.tfa_type)
-    if arguments.tfa_source:
-        Config.set("tfa_source", arguments.tfa_source)
-    if arguments.tfa_retries:
-        Config.set("tfa_retries", arguments.tfa_retries)
-    if arguments.tfa_delay:
-        Config.set("tfa_delay", arguments.tfa_delay)
-    if arguments.tfa_host:
-        Config.set("tfa_host", arguments.tfa_host)
-    if arguments.tfa_username:
-        Config.set("tfa_username", arguments.tfa_username)
-    if arguments.tfa_password:
-        Config.set("tfa_password", arguments.tfa_password)
-    if arguments.debug:
+    if args.save_media_to:
+        Config.set("save_media_to", args.save_media_to)
+    if args.tfa_type:
+        Config.set("tfa_type", args.tfa_type)
+    if args.tfa_source:
+        Config.set("tfa_source", args.tfa_source)
+    if args.tfa_retries:
+        Config.set("tfa_retries", args.tfa_retries)
+    if args.tfa_delay:
+        Config.set("tfa_delay", args.tfa_delay)
+    if args.tfa_host:
+        Config.set("tfa_host", args.tfa_host)
+    if args.tfa_username:
+        Config.set("tfa_username", args.tfa_username)
+    if args.tfa_password:
+        Config.set("tfa_password", args.tfa_password)
+    if args.debug:
         set_logger(True)
     elif (os.environ.get('DEBUG') and os.environ.get('DEBUG') == '1'):
         set_logger(True)
     else:
         set_logger(False)
     try:
-        Init()
+        init()
         loop.run_forever()
     except KeyboardInterrupt:
         sys.exit(0)
     finally:
         loop.close()
 
+
 if __name__ == "__main__":
 
     arguments = parse_arguments()
     main(arguments)
- 

--- a/arlo-downloader.py
+++ b/arlo-downloader.py
@@ -132,26 +132,31 @@ def init() -> None:
     for conf_item in Config.dump_config().items():
         logging.debug(conf_item)
 
-    arlo = pyaarlo.PyArlo(
-        username=username,
-        password=password,
-        tfa_type=Config.config("tfa_type"),
-        tfa_source=Config.config("tfa_source"),
-        tfa_retries=Config.config("tfa_retries"),
-        tfa_delay=Config.config("tfa_delay"),
-        tfa_host=Config.config("tfa_host"),
-        tfa_username=Config.config("tfa_username"),
-        tfa_password=Config.config("tfa_password"),
-        synchronous_mode=False,
-        mode_api="v2",
-        save_state=True,
-        dump=False,
-        storage_dir="aarlo",
-        save_media_to=save_media_to,
-        cipher_list="default",
-        http_connections=5,
-        http_max_size=10,
-    )
+    pyaarlo_opts = {
+        "username": username,
+        "password": password,
+        "tfa_type": Config.config("tfa_type"),
+        "tfa_source": Config.config("tfa_source"),
+        "tfa_retries": Config.config("tfa_retries"),
+        "tfa_delay": Config.config("tfa_delay"),
+        "tfa_host": Config.config("tfa_host"),
+        "tfa_username": Config.config("tfa_username"),
+        "tfa_password": Config.config("tfa_password"),
+        "synchronous_mode": False,
+        "mode_api": "v2",
+        "save_state": True,
+        "dump": False,
+        "storage_dir": "aarlo",
+        "save_media_to": save_media_to,
+        "http_connections": 5,
+        "http_max_size": 10,
+    }
+
+    cipher_list = os.environ.get("CIPHER_LIST")
+    if cipher_list:
+        pyaarlo_opts["cipher_list"] = cipher_list
+
+    arlo = pyaarlo.PyArlo(**pyaarlo_opts)
     if not arlo.is_connected:
         logging.error("failed to login: %s", arlo._last_error)
         sys.exit(1)

--- a/arlo-downloader.py
+++ b/arlo-downloader.py
@@ -33,8 +33,12 @@ def parse_arguments() -> Namespace:
                         action='store_true',
                         help='Enable Debug messages. Can also be set with environment variable DEBUG=1')
     parser.add_argument('-m',
-                        '--save-media-to',
-                        help=f"Save Media naming scheme without extension (default = '{Config.config("save_media_to")}').",
+                        '--media-folder',
+                        help=f"Base folder for media storage (default = '{Config.config("media_folder")}').",
+                        action='store')
+    parser.add_argument('-f',
+                        '--filename',
+                        help=f"File naming pattern using pyaarlo substitutions (default = '{Config.config("filename")}').",
                         action='store')
     parser.add_argument('-t',
                         '--tfa-type',
@@ -97,14 +101,20 @@ def init() -> None:
         logging.info("attribute_changed: %s:%s:%s", device.name, attr, str(value)[:80])
 
     # set these from the environment to log in
-    username = os.environ.get('ARLO_USERNAME', '_INVALID')
-    password = os.environ.get('ARLO_PASSWORD', '_INVALID')
+    username = os.environ.get('ARLO_USERNAME')
+    password = os.environ.get('ARLO_PASSWORD')
+
+    if not username or not password:
+        logging.error("ARLO_USERNAME and ARLO_PASSWORD environment variables are required")
+        sys.exit(1)
+
+    save_media_to = Config.save_media_to()
+    logging.info("save_media_to: %s", save_media_to)
 
     # Print configuration in DEBUG
     for conf_item in Config.dump_config().items():
         logging.debug(conf_item)
-    # log in
-    # add `dump=True` to enable event stream packet dumps
+
     arlo = pyaarlo.PyArlo(username=username, password=password,
                           tfa_type=Config.config('tfa_type'),
                           tfa_source=Config.config('tfa_source'),
@@ -118,10 +128,13 @@ def init() -> None:
                           save_state=True,
                           dump=False,
                           storage_dir='aarlo',
-                          save_media_to=Config.config('save_media_to'))
+                          save_media_to=save_media_to,
+                          cipher_list='default',
+                          http_connections=5,
+                          http_max_size=10)
     if not arlo.is_connected:
-        logging.info("failed to login: %s", arlo._last_error)
-        sys.exit(-1)
+        logging.error("failed to login: %s", arlo._last_error)
+        sys.exit(1)
 
     # get base stations, list their statuses, register state change callbacks
     for base in arlo.base_stations:
@@ -129,10 +142,15 @@ def init() -> None:
         base.add_attr_callback('*', attribute_changed)
 
     # get cameras, list their statuses, register state change callbacks
-    # * is any callback, you can use motionDetected just to get motion events
     for camera in arlo.cameras:
         logging.info("camera: name=%s,device_id=%s,state=%s", camera.name, camera.device_id, camera.state)
         camera.add_attr_callback('*', attribute_changed)
+
+
+async def run_forever():
+    """Keep the event loop running until interrupted."""
+    while True:
+        await asyncio.sleep(3600)
 
 
 def main(args: Namespace):
@@ -143,9 +161,10 @@ def main(args: Namespace):
         args (Namespace): A Namespace containing all arguments
     """
 
-    loop = asyncio.get_event_loop()
-    if args.save_media_to:
-        Config.set("save_media_to", args.save_media_to)
+    if args.media_folder:
+        Config.set("media_folder", args.media_folder)
+    if args.filename:
+        Config.set("filename", args.filename)
     if args.tfa_type:
         Config.set("tfa_type", args.tfa_type)
     if args.tfa_source:
@@ -160,19 +179,16 @@ def main(args: Namespace):
         Config.set("tfa_username", args.tfa_username)
     if args.tfa_password:
         Config.set("tfa_password", args.tfa_password)
-    if args.debug:
-        set_logger(True)
-    elif (os.environ.get('DEBUG') and os.environ.get('DEBUG') == '1'):
+    if args.debug or os.environ.get('DEBUG') == '1':
         set_logger(True)
     else:
         set_logger(False)
+
+    init()
     try:
-        init()
-        loop.run_forever()
+        asyncio.run(run_forever())
     except KeyboardInterrupt:
         sys.exit(0)
-    finally:
-        loop.close()
 
 
 if __name__ == "__main__":

--- a/arlo-downloader.py
+++ b/arlo-downloader.py
@@ -8,10 +8,10 @@ Date:           2022-01-05
 License:        MIT
 """
 
+import asyncio
 import logging
 import os
 import sys
-import asyncio
 from argparse import ArgumentParser, Namespace
 
 import pyaarlo
@@ -27,51 +27,68 @@ def parse_arguments() -> Namespace:
         Namespace: A Namespace containing all arguments
     """
 
-    parser = ArgumentParser(description='Download records from Arlo Cameras.')
-    parser.add_argument('-d',
-                        '--debug',
-                        action='store_true',
-                        help='Enable Debug messages. Can also be set with environment variable DEBUG=1')
-    parser.add_argument('-m',
-                        '--media-folder',
-                        help=f"Base folder for media storage (default = '{Config.config("media_folder")}').",
-                        action='store')
-    parser.add_argument('-f',
-                        '--filename',
-                        help=f"File naming pattern using pyaarlo substitutions (default = '{Config.config("filename")}').",
-                        action='store')
-    parser.add_argument('-t',
-                        '--tfa-type',
-                        choices=['PUSH', 'EMAIL'],
-                        help=f"Set TFA type (default = '{Config.config("tfa_type")}').",
-                        action='store')
-    parser.add_argument('-s',
-                        '--tfa-source',
-                        choices=['push', 'imap'],
-                        help=f"Set TFA source (default = '{Config.config("tfa_source")}').",
-                        action='store')
-    parser.add_argument('-r',
-                        '--tfa-retries',
-                        help=f"Set TFA max retries (default = {Config.config("tfa_retries")}).",
-                        type=int,
-                        action='store')
-    parser.add_argument('-D',
-                        '--tfa-delay',
-                        help=f"Set TFA delay between each check (default = {Config.config("tfa_delay")}).",
-                        type=int,
-                        action='store')
-    parser.add_argument('-H',
-                        '--tfa-host',
-                        help=f"(EMAIL/imap only) Set TFA host (default = {Config.config("tfa_host")}).",
-                        action='store')
-    parser.add_argument('-U',
-                        '--tfa-username',
-                        help=f"(EMAIL/imap only) Set TFA username (default = {Config.config("tfa_username")}).",
-                        action='store')
-    parser.add_argument('-P',
-                        '--tfa-password',
-                        help=f"(EMAIL/imap only) Set TFA password (default = {Config.config("tfa_password")}).",
-                        action='store')
+    parser = ArgumentParser(description="Download records from Arlo Cameras.")
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Enable Debug messages. Can also be set with environment variable DEBUG=1",
+    )
+    parser.add_argument(
+        "-m",
+        "--media-folder",
+        help=f"Base folder for media storage (default = '{Config.config('media_folder')}').",
+        action="store",
+    )
+    parser.add_argument(
+        "-f", "--filename", help=f"File naming pattern (default = '{Config.config('filename')}').", action="store"
+    )
+    parser.add_argument(
+        "-t",
+        "--tfa-type",
+        choices=["PUSH", "EMAIL"],
+        help=f"Set TFA type (default = '{Config.config('tfa_type')}').",
+        action="store",
+    )
+    parser.add_argument(
+        "-s",
+        "--tfa-source",
+        choices=["push", "imap"],
+        help=f"Set TFA source (default = '{Config.config('tfa_source')}').",
+        action="store",
+    )
+    parser.add_argument(
+        "-r",
+        "--tfa-retries",
+        help=f"Set TFA max retries (default = {Config.config('tfa_retries')}).",
+        type=int,
+        action="store",
+    )
+    parser.add_argument(
+        "-D",
+        "--tfa-delay",
+        help=f"Set TFA delay between each check (default = {Config.config('tfa_delay')}).",
+        type=int,
+        action="store",
+    )
+    parser.add_argument(
+        "-H",
+        "--tfa-host",
+        help=f"(EMAIL/imap only) Set TFA host (default = {Config.config('tfa_host')}).",
+        action="store",
+    )
+    parser.add_argument(
+        "-U",
+        "--tfa-username",
+        help=f"(EMAIL/imap only) Set TFA username (default = {Config.config('tfa_username')}).",
+        action="store",
+    )
+    parser.add_argument(
+        "-P",
+        "--tfa-password",
+        help=f"(EMAIL/imap only) Set TFA password (default = {Config.config('tfa_password')}).",
+        action="store",
+    )
     args = parser.parse_args()
     return args
 
@@ -86,23 +103,23 @@ def set_logger(dbg: bool) -> None:
     level = logging.INFO
     if dbg:
         level = logging.DEBUG
-    logging.basicConfig(level=level,
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                        datefmt="%Y-%m-%dT%H:%M:%S%z"
-                        )
+    logging.basicConfig(
+        level=level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"
+    )
 
 
 def init() -> None:
     """
     Initializes the connection to arlo and traps
     """
+
     # code to trap when attributes change
     def attribute_changed(device, attr, value):
         logging.info("attribute_changed: %s:%s:%s", device.name, attr, str(value)[:80])
 
     # set these from the environment to log in
-    username = os.environ.get('ARLO_USERNAME')
-    password = os.environ.get('ARLO_PASSWORD')
+    username = os.environ.get("ARLO_USERNAME")
+    password = os.environ.get("ARLO_PASSWORD")
 
     if not username or not password:
         logging.error("ARLO_USERNAME and ARLO_PASSWORD environment variables are required")
@@ -115,23 +132,26 @@ def init() -> None:
     for conf_item in Config.dump_config().items():
         logging.debug(conf_item)
 
-    arlo = pyaarlo.PyArlo(username=username, password=password,
-                          tfa_type=Config.config('tfa_type'),
-                          tfa_source=Config.config('tfa_source'),
-                          tfa_retries=Config.config('tfa_retries'),
-                          tfa_delay=Config.config('tfa_delay'),
-                          tfa_host=Config.config('tfa_host'),
-                          tfa_username=Config.config('tfa_username'),
-                          tfa_password=Config.config('tfa_password'),
-                          synchronous_mode=False,
-                          mode_api='v2',
-                          save_state=True,
-                          dump=False,
-                          storage_dir='aarlo',
-                          save_media_to=save_media_to,
-                          cipher_list='default',
-                          http_connections=5,
-                          http_max_size=10)
+    arlo = pyaarlo.PyArlo(
+        username=username,
+        password=password,
+        tfa_type=Config.config("tfa_type"),
+        tfa_source=Config.config("tfa_source"),
+        tfa_retries=Config.config("tfa_retries"),
+        tfa_delay=Config.config("tfa_delay"),
+        tfa_host=Config.config("tfa_host"),
+        tfa_username=Config.config("tfa_username"),
+        tfa_password=Config.config("tfa_password"),
+        synchronous_mode=False,
+        mode_api="v2",
+        save_state=True,
+        dump=False,
+        storage_dir="aarlo",
+        save_media_to=save_media_to,
+        cipher_list="default",
+        http_connections=5,
+        http_max_size=10,
+    )
     if not arlo.is_connected:
         logging.error("failed to login: %s", arlo._last_error)
         sys.exit(1)
@@ -139,12 +159,12 @@ def init() -> None:
     # get base stations, list their statuses, register state change callbacks
     for base in arlo.base_stations:
         logging.info("base-name=%s, device_id=%s, state=%s", base.name, base.device_id, base.state)
-        base.add_attr_callback('*', attribute_changed)
+        base.add_attr_callback("*", attribute_changed)
 
     # get cameras, list their statuses, register state change callbacks
     for camera in arlo.cameras:
         logging.info("camera: name=%s,device_id=%s,state=%s", camera.name, camera.device_id, camera.state)
-        camera.add_attr_callback('*', attribute_changed)
+        camera.add_attr_callback("*", attribute_changed)
 
 
 async def run_forever():
@@ -179,7 +199,7 @@ def main(args: Namespace):
         Config.set("tfa_username", args.tfa_username)
     if args.tfa_password:
         Config.set("tfa_password", args.tfa_password)
-    if args.debug or os.environ.get('DEBUG') == '1':
+    if args.debug or os.environ.get("DEBUG") == "1":
         set_logger(True)
     else:
         set_logger(False)
@@ -192,6 +212,5 @@ def main(args: Namespace):
 
 
 if __name__ == "__main__":
-
     arguments = parse_arguments()
     main(arguments)

--- a/config.py
+++ b/config.py
@@ -1,37 +1,82 @@
+#!/usr/bin/env python
+
+"""
+Filename:       config.py
+Description:    configuration class for arlo-downloader.py.
+Author:         Jeremy Diaz <jd@diaznet.ch>
+Date:           2022-01-05
+License:        MIT
+"""
+
 import os
 
+
 class Config:
-  __conf = {
-    "save_media_to": os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "${Y}" + os.path.sep + "${m}" + os.path.sep + "${F}T${t}_${N}_${SN}",
-    "tfa_type": "PUSH",
-    "tfa_source": "push",
-    "tfa_retries": 10,
-    "tfa_delay": 5,
-    "tfa_host": '',
-    "tfa_username": '',
-    "tfa_password": ''
-  }
-  __setters = [
-    "set_logger",
-    "save_media_to",
-    "tfa_type",
-    "tfa_source",
-    "tfa_retries",
-    "tfa_delay",
-    "tfa_host",
-    "tfa_username",
-    "tfa_password"
-    ]
-  @staticmethod
-  def config(name):
-    return Config.__conf[name]
+    """
+    Config class is handling configuration
+    """
 
-  def dump_config():
-    return Config.__conf
+    __conf = {
+      "save_media_to": os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "${Y}" + os.path.sep + "${m}" + os.path.sep + "${F}T${t}_${N}_${SN}",
+      "tfa_type": "PUSH",
+      "tfa_source": "push",
+      "tfa_retries": 10,
+      "tfa_delay": 5,
+      "tfa_host": '',
+      "tfa_username": '',
+      "tfa_password": ''
+    }
+    __setters = [
+      "set_logger",
+      "save_media_to",
+      "tfa_type",
+      "tfa_source",
+      "tfa_retries",
+      "tfa_delay",
+      "tfa_host",
+      "tfa_username",
+      "tfa_password"
+      ]
 
-  @staticmethod
-  def set(name, value):
-    if name in Config.__setters:
-      Config.__conf[name] = value
-    else:
-      raise NameError("Name not accepted in set() method")
+    @staticmethod
+    def config(name: str) -> str:
+        """
+        Returns a key value in the config
+
+        Args:
+            name (str): Name of the key
+
+        Returns:
+            dict: key's value
+        """
+
+        return Config.__conf[name]
+
+    @staticmethod
+    def dump_config() -> dict:
+        """
+        Dumps the whole config
+
+        Returns:
+            dict: dictionnary representing the config
+        """
+
+        return Config.__conf
+
+    @staticmethod
+    def set(name, value):
+        """
+        _summary_
+
+        Args:
+            name (_type_): _description_
+            value (_type_): _description_
+
+        Raises:
+            NameError: _description_
+        """
+
+        if name in Config.__setters:
+            Config.__conf[name] = value
+        else:
+            raise NameError("Name not accepted in set() method")

--- a/config.py
+++ b/config.py
@@ -17,27 +17,27 @@ class Config:
     """
 
     __conf = {
-      "media_folder": os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "records",
-      "filename": "${Y}/${m}/${F}T${t}_${N}_${SN}",
-      "tfa_type": "PUSH",
-      "tfa_source": "push",
-      "tfa_retries": 10,
-      "tfa_delay": 5,
-      "tfa_host": '',
-      "tfa_username": '',
-      "tfa_password": ''
+        "media_folder": os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "records",
+        "filename": "${Y}/${m}/${F}T${t}_${N}_${SN}",
+        "tfa_type": "PUSH",
+        "tfa_source": "push",
+        "tfa_retries": 10,
+        "tfa_delay": 5,
+        "tfa_host": "",
+        "tfa_username": "",
+        "tfa_password": "",
     }
     __setters = [
-      "media_folder",
-      "filename",
-      "tfa_type",
-      "tfa_source",
-      "tfa_retries",
-      "tfa_delay",
-      "tfa_host",
-      "tfa_username",
-      "tfa_password"
-      ]
+        "media_folder",
+        "filename",
+        "tfa_type",
+        "tfa_source",
+        "tfa_retries",
+        "tfa_delay",
+        "tfa_host",
+        "tfa_username",
+        "tfa_password",
+    ]
 
     @staticmethod
     def config(name: str) -> str:

--- a/config.py
+++ b/config.py
@@ -17,7 +17,8 @@ class Config:
     """
 
     __conf = {
-      "save_media_to": os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "${Y}" + os.path.sep + "${m}" + os.path.sep + "${F}T${t}_${N}_${SN}",
+      "media_folder": os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "records",
+      "filename": "${Y}/${m}/${F}T${t}_${N}_${SN}",
       "tfa_type": "PUSH",
       "tfa_source": "push",
       "tfa_retries": 10,
@@ -27,8 +28,8 @@ class Config:
       "tfa_password": ''
     }
     __setters = [
-      "set_logger",
-      "save_media_to",
+      "media_folder",
+      "filename",
       "tfa_type",
       "tfa_source",
       "tfa_retries",
@@ -53,6 +54,16 @@ class Config:
         return Config.__conf[name]
 
     @staticmethod
+    def save_media_to() -> str:
+        """
+        Returns the full save_media_to path for pyaarlo (media_folder + filename).
+
+        Returns:
+            str: combined path
+        """
+        return Config.__conf["media_folder"] + "/" + Config.__conf["filename"]
+
+    @staticmethod
     def dump_config() -> dict:
         """
         Dumps the whole config
@@ -66,14 +77,14 @@ class Config:
     @staticmethod
     def set(name, value):
         """
-        _summary_
+        Sets a config value.
 
         Args:
-            name (_type_): _description_
-            value (_type_): _description_
+            name (str): config key
+            value: config value
 
         Raises:
-            NameError: _description_
+            NameError: if name is not in allowed setters
         """
 
         if name in Config.__setters:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,41 @@
 #!/bin/bash
 
 set -e
-chown -R arlo-downloader:arlo-downloader /records
-/bin/bash -l -c "$*"
-exec exec runuser -u appuser "$@"
+
+# Detect old configuration format where MEDIA_FOLDER contained both path and filename pattern
+if [[ -n "$MEDIA_FOLDER" && "$MEDIA_FOLDER" == *'${'* ]]; then
+    echo "============================================================"
+    echo "ERROR: Breaking changes in this version!"
+    echo ""
+    echo "MEDIA_FOLDER no longer accepts filename patterns."
+    echo "The configuration has been split into two variables:"
+    echo ""
+    echo "  MEDIA_FOLDER = base directory (e.g., /records)"
+    echo "  FILENAME     = naming pattern (e.g., \${Y}/\${m}/\${F}T\${t}_\${N}_\${SN})"
+    echo ""
+    echo "Your current MEDIA_FOLDER contains substitution tokens:"
+    echo "  MEDIA_FOLDER=$MEDIA_FOLDER"
+    echo ""
+    echo "Please update your configuration. See README for details."
+    echo "============================================================"
+    exit 1
+fi
+
+if [[ -z "$MEDIA_FOLDER" ]]; then
+    MEDIA_FOLDER="/records"
+fi
+
+if [[ -z "$FILENAME" ]]; then
+    FILENAME='${Y}/${m}/${F}T${t}_${N}_${SN}'
+fi
+
+exec python /arlo-downloader/arlo-downloader.py \
+    --media-folder "$MEDIA_FOLDER" \
+    --filename "$FILENAME" \
+    --tfa-type "${TFA_TYPE:-PUSH}" \
+    --tfa-source "${TFA_SOURCE:-push}" \
+    --tfa-retries "${TFA_RETRIES:-10}" \
+    --tfa-delay "${TFA_DELAY:-5}" \
+    --tfa-host "${TFA_HOST:-_invalid}" \
+    --tfa-username "${TFA_USERNAME:-###}" \
+    --tfa-password "${TFA_PASSWORD:-###}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "arlo-downloader"
+version = "1.0.0"
+requires-python = ">=3.12"
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "S", "B"]
+ignore = ["S101"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+ruff>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyaarlo==0.8.0.14
+pyaarlo==0.8.0.15
 python-slugify>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyaarlo==0.8.0.15
-python-slugify>=7.0.0
+python-slugify==8.0.4


### PR DESCRIPTION
## Breaking Changes

⚠️ **Configuration format has changed.** The container will detect old config and display a migration message.

`MEDIA_FOLDER` has been split into two separate variables:

| Before (old) | After (new) |
|---|---|
| `MEDIA_FOLDER=/records/${Y}/${m}/${F}T${t}_${N}_${SN}` | `MEDIA_FOLDER=/records` + `FILENAME=${Y}/${m}/${F}T${t}_${N}_${SN}` |

### Migration

Update your docker-compose.yml or environment:

```yaml
environment:
  MEDIA_FOLDER: "/records"
  FILENAME: "$${Y}/$${m}/$${F}T$${t}_$${N}_$${SN}"
```

AI-boosted Changes:

refactor: split config, fix Docker, add CI tests

- Separate MEDIA_FOLDER and FILENAME env vars (breaking change)
- Add deprecation check for old config format
- Fix Dockerfile: layer caching, non-root USER, aarlo state dir
- Fix entrypoint.sh: proper shell variable handling
- Add .dockerignore, .env.example, .gitignore updates
- Remove credentials from docker-compose.yml
- Modernize asyncio usage (asyncio.run)
- Add ruff linting + CI lint/test jobs before build
- Pin dependencies, move ruff to requirements-dev.txt
- Fix Cloudflare 403 with cipher_list option
- Update README with new configuration format
